### PR TITLE
docs: adding more detail in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
 # Animal Tracking Fathom Upload
 
-This tool is used for uploading zip files that contain Fathom CSV files to the Animal Tracking server via CLI.
-
-## Installation (dev)
-
-This tool has been tested with Python 3+
-
-Clone this repo and change working directory to `animaltracking-fathom-upload` 
-
-```bash
-git clone https://github.com/aodn/animaltracking-fathom-upload.git
-cd animaltracking-fathom-upload
-```
-
-Then executing the following command to install required packages:
-
-```bash
-pip install -r requirements.txt
-```
+This tool is used for uploading zip files that contain Fathom CSV files to the Animal Tracking server via a command line interface (CLI).
 
 ## Usage
 
-### If you use Linux/Mac, after downloading `animaltracking`:
+### Download the `animaltracking` executable
+
+It should have already been downloaded if you have clicked on the download link from the [Australian Animal Acoustic Telemetry](https://animaltracking.aodn.org.au/) web-interface while trying to upload your Fathom events and detections ZIP file.
+
+If you haven't downloaded it yet, please [download here](https://github.com/aodn/animaltracking-fathom-upload/raw/main/dist/animaltracking)
+
+### If you use Linux/Mac, open a terminal:
+
+For Mac, click the Launchpad icon in the Dock, type Terminal in the search field, then click Terminal
+For Linux (Ubuntu) press Ctrl+Alt+T .
+
+Change working directory to where you downloaded the file `animaltracking`. 
+If the file is saved in your `Downloads` folder, execute the following:
+
+```bash
+cd ~/Downloads
+```
+
+Then run:
 
 ```bash
 chmod +x animaltracking
@@ -37,6 +38,23 @@ Note: you might be warned about the `.exe` file, click "Keep/Run anyway" or "Con
 
 
 ### If you use the `animaltracking.py` file directly:
+
+This tool has been tested with Python 3+
+
+Clone this repo and change working directory to `animaltracking-fathom-upload` 
+
+```bash
+git clone https://github.com/aodn/animaltracking-fathom-upload.git
+cd animaltracking-fathom-upload
+```
+
+Then execute the following command to install the required packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+Finally, run the Python script:
 
 ```bash
 python animaltracking.py


### PR DESCRIPTION
Here are some suggestions for the readme file. 

I moved the "installation` section towards the bottom as I believe only few users will use the option of cloning the repo and running the python script on their machine